### PR TITLE
MEX-459 "Confirmed" checkbox in Diagnosis wiget should instead say "First time" ("1a vez")

### DIFF
--- a/mirebalais-modules/openmrs/files/app-data-config/mexico/configuration/messageproperties/metadata_en.properties
+++ b/mirebalais-modules/openmrs/files/app-data-config/mexico/configuration/messageproperties/metadata_en.properties
@@ -1,0 +1,4 @@
+# CES is using the "Confirmed" checkbox as if it meant "1a vez", which
+# more or less means "new diagnosis" or "first visit for this problem."
+# See https://pihemr.atlassian.net/browse/MEX-459
+coreapps.Diagnosis.Certainty.CONFIRMED=First time

--- a/mirebalais-modules/openmrs/files/app-data-config/mexico/configuration/messageproperties/metadata_es.properties
+++ b/mirebalais-modules/openmrs/files/app-data-config/mexico/configuration/messageproperties/metadata_es.properties
@@ -1,0 +1,4 @@
+# CES is using the "Confirmed" checkbox as if it meant "1a vez", which
+# more or less means "new diagnosis" or "first visit for this problem."
+# See https://pihemr.atlassian.net/browse/MEX-459
+coreapps.Diagnosis.Certainty.CONFIRMED=1a vez


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/MEX-459

Initializer pulls in the message property from the `configuration/messageproperties` directory. Anything defined there become the top-priority message. These configurations correspond to a single country. Thus this allows us to override a message property just for Mexico.