### PR TITLE
Fix SPA deps so they come from CDN

### DIFF
--- a/mirebalais-modules/openmrs/files/import-map.ci.json
+++ b/mirebalais-modules/openmrs/files/import-map.ci.json
@@ -10,11 +10,11 @@
       "@openmrs/esm-primary-navigation": "https://bamboo.pih-emr.org:81/spa-repo/openmrs-esm-primary-navigation/unstable/openmrs-esm-primary-navigation.js",
       "@openmrs/esm-root-config": "https://bamboo.pih-emr.org:81/spa-repo/pih-esm-root-config/unstable/pih-esm-root-config.js",
       "@openmrs/esm-styleguide": "https://bamboo.pih-emr.org:81/spa-repo/openmrs-esm-styleguide/unstable/openmrs-esm-styleguide.js",
-      "i18next": "https://cdn.jsdelivr.net/npm/i18next@19.3.3/dist/umd/i18next.min.js",
-      "react": "/openmrs/frontend/react@16.13.0/umd/react.production.min.js",
-      "react-dom": "/openmrs/frontend/react-dom@16.13.0/umd/react-dom.production.min.js",
+      "i18next": "https://cdn.jsdelivr.net/npm/i18next@19.3.3/dist/umd/i18next.js",
+      "react": "https://cdn.jsdelivr.net/npm/react@16.13.1/umd/react.development.js",
+      "react-dom": "https://cdn.jsdelivr.net/npm/react-dom@16.13.1/umd/react-dom.development.js",
       "react-i18next": "https://cdn.jsdelivr.net/npm/react-i18next@11.3.3/dist/umd/react-i18next.min.js",
-      "rxjs": "/openmrs/frontend/rxjs@6.5.4/bundles/rxjs.umd.min.js",
+      "rxjs": "https://cdn.jsdelivr.net/npm/rxjs@6.5.4/bundles/rxjs.umd.min.js",
       "single-spa": "https://cdn.jsdelivr.net/npm/single-spa@5.1.1/lib/system/single-spa.min.js"
     }
   }


### PR DESCRIPTION
[SPA on CI](ci.pih-emr.org/openmrs/spa/login) is failing right now. See that in the current [import-map](https://ci.pih-emr.org/openmrs/frontend/import-map.json), a few of the dependencies are getting pulled from local directories that don't exist, rather than the CDN.