### PR TITLE
Add hack to fix webapp name in SPA application 

### DIFF
--- a/mirebalais-modules/openmrs/manifests/init.pp
+++ b/mirebalais-modules/openmrs/manifests/init.pp
@@ -204,6 +204,13 @@ class openmrs (
     notify => [ Exec['tomcat-restart'] ]
   }
 
+  # hack to change webapp name in the frontend application after it has already been built into the deb
+  exec {
+    unless  => "test ${webapp_name} = openmrs",
+    command => "sed -i 's/\/openmrs\([\/\"]\)/\/${webapp_name}\1/g' /home/${tomcat}/.OpenMRS/frontend/index.html",
+    require => Package['pihemr']
+  }
+
   exec { 'tomcat-restart':
     command     => "service ${tomcat} restart",
     user        => 'root',

--- a/mirebalais-modules/openmrs/manifests/init.pp
+++ b/mirebalais-modules/openmrs/manifests/init.pp
@@ -205,7 +205,7 @@ class openmrs (
   }
 
   # hack to change webapp name in the frontend application after it has already been built into the deb
-  exec {
+  exec { 'fix spa application webapp name':
     unless  => "test ${webapp_name} = openmrs",
     command => "sed -i 's/\/openmrs\([\/\"]\)/\/${webapp_name}\1/g' /home/${tomcat}/.OpenMRS/frontend/index.html",
     require => Package['pihemr']


### PR DESCRIPTION
https://pihemr.atlassian.net/browse/UHM-5276

Unfortunately, since SPA path and API path are set at application build time, and since we only have one distribution which we deploy to different servers with different webapp names, we need an ugly hack. This changes the SPA path and API path on servers for which they aren't the default.