### PR TITLE
Make package name a variable

### DIFF
--- a/hieradata/common.yaml
+++ b/hieradata/common.yaml
@@ -9,6 +9,7 @@ ntp_server_4: 3.ubuntu.pool.ntp.org
 pih_config: default
 site_domain: foo.org
 
+package_name: pihemr
 package_release: 'unstable/'
 package_version: '1.0.6193-1'
 

--- a/hieradata/peru-ci.pih-emr.org.yaml
+++ b/hieradata/peru-ci.pih-emr.org.yaml
@@ -1,6 +1,8 @@
 ---
 site_domain: peru-ci.pih-emr.org
 
+package_name: ses-cor
+
 pih_config: peru
 config_name: openmrs-config-ses
 config_version: 1.5.0-SNAPSHOT

--- a/mirebalais-modules/mirth/manifests/init.pp
+++ b/mirebalais-modules/mirth/manifests/init.pp
@@ -4,13 +4,14 @@ class mirth(
   $mirth_db_password = decrypt(hiera('mirth_db_password')),
   $services_ensure = hiera('services_ensure'),
   $services_enable = hiera('services_enable'),
-  $openmrs_db = hiera('openmrs_db')
+  $openmrs_db = hiera('openmrs_db'),
+  $package_name = hiera('package_name')
 ){
 
   mysql_database { $mirth_db :
     ensure  => present,
     charset => 'utf8',
-    require => [Service['mysqld'], Package['pihemr']],
+    require => [Service['mysqld'], Package[$package_name]],
   }
 
   mysql_user { "${mirth_db_user}@localhost":

--- a/mirebalais-modules/openmrs/manifests/atomfeed.pp
+++ b/mirebalais-modules/openmrs/manifests/atomfeed.pp
@@ -2,14 +2,14 @@ class openmrs::atomfeed (
         $openmrs_modules_dir  = hiera('openmrs_modules_dir'),
         $atomfeed_version     = hiera('atomfeed_version'),
         $atomfeed_repo_url    = hiera('atomfeed_repo_url'),
-        $tomcat               = hiera('tomcat')
-
+        $tomcat               = hiera('tomcat'),
+        $package_name = hiera('package_name')
 ) {
 
   exec {'download_atomfeed_omod':
    command => "/usr/bin/wget -q ${atomfeed_repo_url}/org/openmrs/module/atomfeed-omod/${atomfeed_version}/atomfeed-omod-${atomfeed_version}.jar -O  ${openmrs_modules_dir}/atomfeed-${atomfeed_version}.omod",
-   require => Package['pihemr']
-}
+   require => Package[$package_name]
+  }
 
   file { "atomfeed":
     path => "$openmrs_modules_dir/atomfeed-${atomfeed_version}.omod",

--- a/mirebalais-modules/openmrs/manifests/initial_setup.pp
+++ b/mirebalais-modules/openmrs/manifests/initial_setup.pp
@@ -2,19 +2,20 @@ class openmrs::initial_setup(
   $openmrs_db = hiera('openmrs_db'),
   $openmrs_db_user = decrypt(hiera('openmrs_db_user')),
   $openmrs_db_password = decrypt(hiera('openmrs_db_password')),
-  $tomcat = hiera('tomcat')
+  $tomcat = hiera('tomcat'),
+  $package_name = hiera('package_name')
 ) {
 
   mysql_database { $openmrs_db :
     ensure  => present,
-    require => [Service['mysqld'],  Package['pihemr']],
+    require => [Service['mysqld'],  Package[$package_name]],
     charset => 'utf8',
   } ->
 
   mysql_user { "${openmrs_db_user}@localhost":
     ensure        => present,
     password_hash => mysql_password($openmrs_db_password),
-    require => [ Service['mysqld'], Package['pihemr']],
+    require => [ Service['mysqld'], Package[$package_name]],
   } ->
 
   mysql_grant { "${openmrs_db_user}@localhost/${openmrs_db}":
@@ -22,7 +23,7 @@ class openmrs::initial_setup(
     privileges => ['ALL'],
     table => '*.*',
     user => "${openmrs_db_user}@localhost",
-    require => [ Service['mysqld'],  Package['pihemr']],
+    require => [ Service['mysqld'],  Package[$package_name]],
   } ->
 
   mysql_grant { "root@localhost/${openmrs_db}":
@@ -30,7 +31,7 @@ class openmrs::initial_setup(
     privileges => ['ALL'],
     table => '*.*',
     user => "root@localhost",
-    require => [Service['mysqld'],  Package['pihemr']],
+    require => [Service['mysqld'],  Package[$package_name]],
     notify  => Openmrs::Liquibase_migrate['set up base schema'];
   }
 

--- a/mirebalais-modules/openmrs/manifests/liquibase_migrate.pp
+++ b/mirebalais-modules/openmrs/manifests/liquibase_migrate.pp
@@ -6,7 +6,8 @@ define openmrs::liquibase_migrate(
   $openmrs_db_user = decrypt(hiera('openmrs_db_user')),
   $openmrs_db_password = decrypt(hiera('openmrs_db_password')),
   $webapp_name = hiera('webapp_name'),
-  $tomcat = hiera('tomcat')
+  $tomcat = hiera('tomcat'),
+  $package_name = hiera('package_name')
 ) {
 
   require openmrs
@@ -17,7 +18,7 @@ define openmrs::liquibase_migrate(
     command     => "java -Dliquibase.databaseChangeLogTableName=liquibasechangelog -Dliquibase.databaseChangeLogLockTableName=liquibasechangeloglock -jar liquibase.jar --driver=com.mysql.jdbc.Driver --classpath=/var/lib/${tomcat}/webapps/${webapp_name}.war --url=jdbc:mysql://localhost:3306/${openmrs_db} --changeLogFile=${dataset} --username=${openmrs_db_user} --password='${openmrs_db_password}' update",
     user        => 'root',
     unless      => $unless,
-    require     => [ File['/usr/local/liquibase.jar'], Package['pihemr'] ],
+    require     => [ File['/usr/local/liquibase.jar'], Package[$package_name] ],
     refreshonly => $refreshonly,
     timeout => 0,
   }


### PR DESCRIPTION
This allows installing packages other than `pihemr` using the `package_name` variable, which defaults to `pihemr`.

`peru-ci` is set to use `ses-cor`, which is the debian package created by the COR EMR Debian Package [job](https://bamboo.pih-emr.org/browse/PERU-CEDP).